### PR TITLE
Fixed a mistake when counting arguments

### DIFF
--- a/README.md
+++ b/README.md
@@ -15,7 +15,7 @@ set_pixel(0,255,0,0)
 show()
 ```
 
-`set_pixel` takes an optional forth parameter; the brightness from 0.0 to 1.0.
+`set_pixel` takes an optional fifth parameter; the brightness from 0.0 to 1.0.
 
 You can also change the brightness with `set_brightness` from 0.0 to 1.0, for example:
 


### PR DESCRIPTION
The optional brightness parameter is parameter number five, not four.
(And if it was parameter number four, the correct spelling is "fourth".)

``` python
set_pixel(pixel_no, red, green, blue, brightness)
```

---

Note: I'm unfamiliar with Python. As far as I'm aware though, while array indices start at 0, numbering of arguments starts at 1. If this is not the case, please close this PR. 
