### PR TITLE
Initial version of Dockerfile tested on Pi Zero

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,0 +1,12 @@
+FROM resin/rpi-raspbian:jessie
+
+RUN apt-get update -qy && apt-get install -qy \
+    python \
+    python-rpi.gpio
+WORKDIR /root/
+COPY . .
+WORKDIR /root/library
+RUN python setup.py install
+WORKDIR /root/examples/
+ENTRYPOINT []
+CMD ["python", "larson.py"]


### PR DESCRIPTION
#### What I did:
Initial working Dockerfile for Pi Zero. Looking forward to using this at Dockercon - http://2017.dockercon.com/workshops/

#### How I tested it:

```
pi@raspberrypi:~/blinkt $ docker build -t blinkt .
Sending build context to Docker daemon 807.4 kB
Step 1 : FROM resin/rpi-raspbian:jessie
 ---> c939d881f4e0
Step 2 : RUN apt-get update -qy && apt-get install -qy     python     python-rpi.gpio
 ---> Using cache
 ---> 48b7c5b3083a
Step 3 : WORKDIR /root/
 ---> Using cache
 ---> 080f35dd521e
Step 4 : COPY . .
 ---> 871a4e5a5a84
Removing intermediate container 06cdca3d62a1
Step 5 : WORKDIR /root/library
 ---> Running in 772b47c9689a
 ---> 84b8bb369e0a
Removing intermediate container 772b47c9689a
Step 6 : RUN python setup.py install
 ---> Running in cb0c5d2858d4
/usr/lib/python2.7/distutils/dist.py:267: UserWarning: Unknown distribution option: 'install_requires'
  warnings.warn(msg)
running install
running build
running build_py
running install_lib
copying build/lib.linux-armv6l-2.7/blinkt.py -> /usr/local/lib/python2.7/dist-packages
byte-compiling /usr/local/lib/python2.7/dist-packages/blinkt.py to blinkt.pyc
running install_egg_info
Writing /usr/local/lib/python2.7/dist-packages/blinkt-0.1.0.egg-info
 ---> 98d9c92c9513
Removing intermediate container cb0c5d2858d4
Step 7 : WORKDIR /root/examples/
 ---> Running in 2fd158a53f48
 ---> 3b4bcccda47f
Removing intermediate container 2fd158a53f48
Step 8 : ENTRYPOINT 
 ---> Running in 6be686273bd0
 ---> dd7608ac56ca
Removing intermediate container 6be686273bd0
Step 9 : CMD python larson.py
 ---> Running in 310b81b8cd3c
 ---> 0a87865bc3b0
Removing intermediate container 310b81b8cd3c
Successfully built 0a87865bc3b0

```

Then to run it:

```
# docker run --privileged --name blinkt -d blinkt

# To kill container later...

# docker rm -f blinkt
```

Signed-off-by: Alex Ellis <alexellis2@gmail.com>