### PR TITLE
Apple HomeKit support for Blinkt

### DIFF
--- a/README.md
+++ b/README.md
@@ -27,7 +27,7 @@ on Raspbian:
 ```bash
 sudo apt-get install python3-blinkt
 ```
-other environments: 
+other environments:
 
 ```bash
 sudo pip3 install blinkt
@@ -40,7 +40,7 @@ on Raspbian:
 ```bash
 sudo apt-get install python-blinkt
 ```
-other environments: 
+other environments:
 
 ```bash
 sudo pip2 install blinkt
@@ -80,5 +80,8 @@ show()
 ##Examples
 
 The examples in the `examples` folder should just work with Blinkt!, although you'll need to add Twitter developer access tokens and secrets in the `twitter_monitor.py` example. You can get these at [https://dev.twitter.com/](https://dev.twitter.com/), after setting up a new application.
+
+###HomeKit Example
+
 
 The examples in the `examples/extra_examples` folder are designed to work with other pHATs and HATs, so be aware of that before trying them.

--- a/README.md
+++ b/README.md
@@ -83,5 +83,67 @@ The examples in the `examples` folder should just work with Blinkt!, although yo
 
 ###HomeKit Example
 
+Based on the Using Mote with Homekit and Siri tutorial (https://learn.pimoroni.com/tutorial/sandyj/using-mote-with-homekit-and-siri) and modified to support Blinkt by Phil Robinson (https://github.com/philprobinson84/blinkt).
 
+Borrow the easy setup of Flask and Mote from the aforementioned guide:
+```bash
+curl -sS get.pimoroni.com/mote | bash
+```
+Next, run:
+```bash
+sudo python homekit.py
+```
+Then, open another terminal window or tab, and type the following to test that our API is working as expected.
+```bash
+curl -i http://127.0.0.1:5000/blinkt/api/v1.0/on
+```
+That should have just turned your blinkt on! You should also be able to do this remotely, on another machine, replacing the 127.0.0.1 part of the URL with the IP address of the machine on which your API is running. You should also be able to do this in your web browser rather than with curl in the terminal.
+
+Try typing the following to change the colour of the blinkt LEDs to red.
+```bash
+curl -i http://127.0.0.1:5000/blinkt/api/v1.0/set/FF0000
+```
+Set brightness (doesn't change the colour):
+```bash
+curl -i http://127.0.0.1:5000/blinkt/api/v1.0/brightness/50
+```
+N.B. Homebridge, and therefore our API, uses a brightness value of 0 to 100, which is translated by homekit.py to the range 0 to 1 required by the blinkt Python library.
+
+Now for Homebridge installation and setup.
+
+Open a terminal, and type the following to upgrade to the latest and greatest version of Node.js:
+```bash
+sudo apt-get update
+sudo apt-get upgrade
+curl -sL https://deb.nodesource.com/setup_6.x | sudo -E bash -
+sudo apt-get install -y nodejs
+```
+Before we install homebridge, we'll also need to install a couple of dependencies. Type the following to install them:
+```bash
+sudo apt-get install libavahi-compat-libdnssd-dev
+```
+Now, we can install homebridge itself, as well as the homebridge-better-http-rgb plugin:
+```bash
+sudo npm install -g --unsafe-perm homebridge
+sudo npm install -g --unsafe-perm homebridge-better-http-rgb
+```
+Now that everything is installed, we have to do a couple more things to configure homebridge correctly. homebridge is configured through a .json file that must be put into the /home/pi/.homebridge/ directory. We'll create that directory now:
+```bash
+mkdir /home/pi/.homebridge
+```
+Now we'll copy the example JSON file over, change directory to wherever the blinkt examples reside, then:
+```bash
+cp homekit-sample-config.json /home/pi/.homebridge/config.json
+```
+To run everything, first we start the Python script:
+```bash
+sudo python homekit.py
+```
+Then in another teminal just type:
+```bash
+homebridge
+```
+If you're running iOS 10 or above, you can now open the Home app and the device will be shown, allowing you to change colour, brightness and other goodness. Enjoy!
+
+###Extra Examples
 The examples in the `examples/extra_examples` folder are designed to work with other pHATs and HATs, so be aware of that before trying them.

--- a/README.md
+++ b/README.md
@@ -145,5 +145,8 @@ homebridge
 ```
 If you're running iOS 10 or above, you can now open the Home app and the device will be shown, allowing you to change colour, brightness and other goodness. Enjoy!
 
+####HomeKit_Multi
+There's also an example which configures HomeKit to address each LED separately - instructions and usage is almost identical to the HomeKit example, just look at the files `examples/homekit_multi.py` and `examples/homekit_multi-sample-config.json`.
+
 ###Extra Examples
 The examples in the `examples/extra_examples` folder are designed to work with other pHATs and HATs, so be aware of that before trying them.

--- a/examples/homekit-sample-config.json
+++ b/examples/homekit-sample-config.json
@@ -32,5 +32,21 @@
         }
     ],
 
-    "platforms": []
+    "platforms": [
+        {
+          "platform": "Camera-ffmpeg",
+          "cameras": [
+          {
+          "name": "PiCam",
+          "videoConfig": {
+            "source": "-re -i rtsp://127.0.0.1:8081",
+            "stillImageSource": "-i http://127.0.0.1:8081",
+            "maxStreams": 2,
+            "maxWidth": 1280,
+            "maxHeight": 720,
+            "maxFPS": 30
+            }
+          }
+        ]}
+    ]
 }

--- a/examples/homekit-sample-config.json
+++ b/examples/homekit-sample-config.json
@@ -1,0 +1,36 @@
+{
+    "bridge": {
+        "name": "Homebridge",
+        "username": "CC:22:3D:E3:CE:32",
+        "port": 51826,
+        "pin": "031-45-155"
+    },
+
+    "description": "Homebridge",
+
+    "accessories": [
+        {
+            "accessory": "HTTP-RGB",
+            "name": "Blinkt",
+
+            "switch": {
+                "status": "http://127.0.0.1:5000/blinkt/api/v1.0/status",
+                "powerOn": "http://127.0.0.1:5000/blinkt/api/v1.0/on",
+                "powerOff": "http://127.0.0.1:5000/blinkt/api/v1.0/off"
+            },
+
+            "brightness": {
+                "status": "http://127.0.0.1:5000/blinkt/api/v1.0/brightness",
+                "url": "http://127.0.0.1:5000/blinkt/api/v1.0/brightness/%s"
+            },
+
+            "color": {
+                "status": "http://127.0.0.1:5000/blinkt/api/v1.0/set",
+                "url": "http://127.0.0.1:5000/blinkt/api/v1.0/set/%s",
+                "brightness": true
+            }
+        }
+    ],
+
+    "platforms": []
+}

--- a/examples/homekit-sample-config.json
+++ b/examples/homekit-sample-config.json
@@ -32,21 +32,5 @@
         }
     ],
 
-    "platforms": [
-        {
-          "platform": "Camera-ffmpeg",
-          "cameras": [
-          {
-          "name": "PiCam",
-          "videoConfig": {
-            "source": "-re -i rtsp://127.0.0.1:8081",
-            "stillImageSource": "-i http://127.0.0.1:8081",
-            "maxStreams": 2,
-            "maxWidth": 1280,
-            "maxHeight": 720,
-            "maxFPS": 30
-            }
-          }
-        ]}
-    ]
+    "platforms": []
 }

--- a/examples/homekit.py
+++ b/examples/homekit.py
@@ -63,12 +63,12 @@ def set_status(st):
         blinkt_off()
     elif st == 'status':
         status = get_status()
-    return status
+    return str(status)
 
 @app.route('/blinkt/api/v1.0/set', methods=['GET'])
 def get_colour():
     global colour, brightness
-    return colour
+    return str(colour)
 
 @app.route('/blinkt/api/v1.0/set/<string:c>', methods=['GET'])
 def set_colour(c):
@@ -77,12 +77,12 @@ def set_colour(c):
     if status != 0:
         blinkt_on(colour)
         status = 1
-    return colour
+    return str(colour)
 
 @app.route('/blinkt/api/v1.0/brightness', methods=['GET'])
 def get_brightness():
     global colour, brightness
-    return brightness
+    return str(brightness)
 
 @app.route('/blinkt/api/v1.0/brightness/<string:x>', methods=['GET'])
 def set_brightness(x):
@@ -91,7 +91,7 @@ def set_brightness(x):
     if status != 0:
         blinkt_on(colour)
         status = 1
-    return brightness
+    return str(brightness)
 
 @app.errorhandler(404)
 def not_found(error):

--- a/examples/homekit.py
+++ b/examples/homekit.py
@@ -63,12 +63,12 @@ def set_status(st):
         blinkt_off()
     elif st == 'status':
         status = get_status()
-    return jsonify({'status': status, 'colour': colour, 'brightness' : brightness})
+    return status
 
 @app.route('/blinkt/api/v1.0/set', methods=['GET'])
 def get_colour():
     global colour, brightness
-    return jsonify({'status': status, 'colour': colour, 'brightness' : brightness})
+    return colour
 
 @app.route('/blinkt/api/v1.0/set/<string:c>', methods=['GET'])
 def set_colour(c):
@@ -77,12 +77,12 @@ def set_colour(c):
     if status != 0:
         blinkt_on(colour)
         status = 1
-    return jsonify({'status': status, 'colour': colour, 'brightness' : brightness})
+    return colour
 
 @app.route('/blinkt/api/v1.0/brightness', methods=['GET'])
 def get_brightness():
     global colour, brightness
-    return jsonify({'status': status, 'colour': colour, 'brightness' : brightness})
+    return brightness
 
 @app.route('/blinkt/api/v1.0/brightness/<string:x>', methods=['GET'])
 def set_brightness(x):
@@ -91,7 +91,7 @@ def set_brightness(x):
     if status != 0:
         blinkt_on(colour)
         status = 1
-    return jsonify({'status': status, 'colour': colour, 'brightness' : brightness})
+    return brightness
 
 @app.errorhandler(404)
 def not_found(error):

--- a/examples/homekit.py
+++ b/examples/homekit.py
@@ -11,6 +11,7 @@ blinkt.show()
 
 colour = 'FFFFFF'
 status = 0
+brightness = 0.2
 
 # Unlike the mote library, the blinkt library doesn't have a get_pixel function so we'll need to keep track of things ourselves...
 anyLEDon = 0
@@ -21,9 +22,10 @@ def hex_to_rgb(value):
     return tuple(int(value[i:i + length / 3], 16) for i in range(0, length, length / 3))
 
 def blinkt_on(c):
+    global brightness
     r, g, b = hex_to_rgb(c)
     for pixel in range(8):
-        blinkt.set_pixel(pixel, r, g, b)
+        blinkt.set_pixel(pixel, r, g, b, brightness)
     anyLEDon = 1
     blinkt.show()
     return True
@@ -34,6 +36,16 @@ def blinkt_off():
     anyLEDon = 0
     return True
 
+def blinkt_brightness_get():
+    global brightness
+    return brightness
+
+def blinkt_brightness_set(newbrightness):
+    global brightness, colour
+    brightness = newbrightness
+    blinkt_on(colour)
+    return True
+
 def get_status():
     global status
     if anyLEDon != 0:
@@ -42,7 +54,7 @@ def get_status():
 
 @app.route('/blinkt/api/v1.0/<string:st>', methods=['GET'])
 def set_status(st):
-    global status, colour
+    global status, colour, brightness
     if st == 'on':
         status = 1
         blinkt_on(colour)
@@ -51,21 +63,35 @@ def set_status(st):
         blinkt_off()
     elif st == 'status':
         status = get_status()
-    return jsonify({'status': status, 'colour': colour})
+    return jsonify({'status': status, 'colour': colour, 'brightness' : brightness})
 
 @app.route('/blinkt/api/v1.0/set', methods=['GET'])
 def get_colour():
-    global colour
-    return jsonify({'status': status, 'colour': colour})
+    global colour, brightness
+    return jsonify({'status': status, 'colour': colour, 'brightness' : brightness})
 
 @app.route('/blinkt/api/v1.0/set/<string:c>', methods=['GET'])
 def set_colour(c):
-    global status, colour
+    global status, colour, brightness
     colour = c
     if status != 0:
         blinkt_on(colour)
         status = 1
-    return jsonify({'status': status, 'colour': colour})
+    return jsonify({'status': status, 'colour': colour, 'brightness' : brightness})
+
+@app.route('/blinkt/api/v1.0/brightness', methods=['GET'])
+def get_brightness():
+    global colour, brightness
+    return jsonify({'status': status, 'colour': colour, 'brightness' : brightness})
+
+@app.route('/blinkt/api/v1.0/brightness/<string:c>', methods=['GET'])
+def set_brightness(x):
+    global status, colour, brightness
+    brightness = x
+    if status != 0:
+        blinkt_on(colour)
+        status = 1
+    return jsonify({'status': status, 'colour': colour, 'brightness' : brightness})
 
 @app.errorhandler(404)
 def not_found(error):

--- a/examples/homekit.py
+++ b/examples/homekit.py
@@ -63,12 +63,12 @@ def set_status(st):
         blinkt_off()
     elif st == 'status':
         status = get_status()
-    return jsonify({'status': status, 'colour': colour, 'brightness' : brightness})
+    return jsonify(status)
 
 @app.route('/blinkt/api/v1.0/set', methods=['GET'])
 def get_colour():
     global colour, brightness
-    return jsonify({'status': status, 'colour': colour, 'brightness' : brightness})
+    return jsonify(colour)
 
 @app.route('/blinkt/api/v1.0/set/<string:c>', methods=['GET'])
 def set_colour(c):
@@ -82,7 +82,7 @@ def set_colour(c):
 @app.route('/blinkt/api/v1.0/brightness', methods=['GET'])
 def get_brightness():
     global colour, brightness
-    return jsonify({'status': status, 'colour': colour, 'brightness' : brightness})
+    return jsonify(brightness)
 
 @app.route('/blinkt/api/v1.0/brightness/<string:x>', methods=['GET'])
 def set_brightness(x):

--- a/examples/homekit.py
+++ b/examples/homekit.py
@@ -5,7 +5,7 @@ from flask import Flask, jsonify, make_response
 app = Flask(__name__)
 
 # Initialize blinkt device
-blinkt.set_clear_on_exit()
+blinkt.set_clear_on_exit(True)
 blinkt.clear()
 blinkt.show()
 

--- a/examples/homekit.py
+++ b/examples/homekit.py
@@ -11,7 +11,7 @@ blinkt.show()
 
 colour = 'FFFFFF'
 status = 0
-brightness = 0.2
+brightness = 50
 
 # Unlike the mote library, the blinkt library doesn't have a get_pixel function so we'll need to keep track of things ourselves...
 anyLEDon = 0
@@ -25,7 +25,7 @@ def blinkt_on(c):
     global brightness
     r, g, b = hex_to_rgb(c)
     for pixel in range(8):
-        blinkt.set_pixel(pixel, r, g, b, brightness)
+        blinkt.set_pixel(pixel, r, g, b, float(brightness)/100)
     anyLEDon = 1
     blinkt.show()
     return True
@@ -84,10 +84,10 @@ def get_brightness():
     global colour, brightness
     return jsonify({'status': status, 'colour': colour, 'brightness' : brightness})
 
-@app.route('/blinkt/api/v1.0/brightness/<float:x>', methods=['GET'])
+@app.route('/blinkt/api/v1.0/brightness/<string:x>', methods=['GET'])
 def set_brightness(x):
     global status, colour, brightness
-    brightness = x
+    brightness = int(x)
     if status != 0:
         blinkt_on(colour)
         status = 1

--- a/examples/homekit.py
+++ b/examples/homekit.py
@@ -84,7 +84,7 @@ def get_brightness():
     global colour, brightness
     return jsonify({'status': status, 'colour': colour, 'brightness' : brightness})
 
-@app.route('/blinkt/api/v1.0/brightness/<string:c>', methods=['GET'])
+@app.route('/blinkt/api/v1.0/brightness/<float:x>', methods=['GET'])
 def set_brightness(x):
     global status, colour, brightness
     brightness = x

--- a/examples/homekit.py
+++ b/examples/homekit.py
@@ -63,12 +63,12 @@ def set_status(st):
         blinkt_off()
     elif st == 'status':
         status = get_status()
-    return status
+    return jsonify({'status': status, 'colour': colour, 'brightness' : brightness})
 
 @app.route('/blinkt/api/v1.0/set', methods=['GET'])
 def get_colour():
     global colour, brightness
-    return colour
+    return jsonify({'status': status, 'colour': colour, 'brightness' : brightness})
 
 @app.route('/blinkt/api/v1.0/set/<string:c>', methods=['GET'])
 def set_colour(c):
@@ -77,12 +77,12 @@ def set_colour(c):
     if status != 0:
         blinkt_on(colour)
         status = 1
-    return colour
+    return jsonify({'status': status, 'colour': colour, 'brightness' : brightness})
 
 @app.route('/blinkt/api/v1.0/brightness', methods=['GET'])
 def get_brightness():
     global colour, brightness
-    return brightness
+    return jsonify({'status': status, 'colour': colour, 'brightness' : brightness})
 
 @app.route('/blinkt/api/v1.0/brightness/<string:x>', methods=['GET'])
 def set_brightness(x):
@@ -91,7 +91,7 @@ def set_brightness(x):
     if status != 0:
         blinkt_on(colour)
         status = 1
-    return brightness
+    return jsonify({'status': status, 'colour': colour, 'brightness' : brightness})
 
 @app.errorhandler(404)
 def not_found(error):

--- a/examples/homekit.py
+++ b/examples/homekit.py
@@ -1,0 +1,76 @@
+from colorsys import hsv_to_rgb, rgb_to_hsv
+import blinkt
+from flask import Flask, jsonify, make_response
+
+app = Flask(__name__)
+
+# Initialize blinkt device
+blinkt.set_clear_on_exit()
+blinkt.clear()
+blinkt.show()
+
+colour = 'FFFFFF'
+status = 0
+
+# Unlike the mote library, the blinkt library doesn't have a get_pixel function so we'll need to keep track of things ourselves...
+anyLEDon = 0
+
+def hex_to_rgb(value):
+    value = value.lstrip('#')
+    length = len(value)
+    return tuple(int(value[i:i + length / 3], 16) for i in range(0, length, length / 3))
+
+def blinkt_on(c):
+    r, g, b = hex_to_rgb(c)
+    for pixel in range(8):
+        blinkt.set_pixel(pixel, r, g, b)
+    anyLEDon = 1
+    blinkt.show()
+    return True
+
+def blinkt_off():
+    blinkt.clear()
+    blinkt.show()
+    anyLEDon = 0
+    return True
+
+def get_status():
+    global status
+    if anyLEDon != 0:
+        status = 1
+    return status
+
+@app.route('/blinkt/api/v1.0/<string:st>', methods=['GET'])
+def set_status(st):
+    global status, colour
+    if st == 'on':
+        status = 1
+        blinkt_on(colour)
+    elif st == 'off':
+        status = 0
+        blinkt_off()
+    elif st == 'status':
+        status = get_status()
+    return jsonify({'status': status, 'colour': colour})
+
+@app.route('/blinkt/api/v1.0/set', methods=['GET'])
+def get_colour():
+    global colour
+    return jsonify({'status': status, 'colour': colour})
+
+@app.route('/blinkt/api/v1.0/set/<string:c>', methods=['GET'])
+def set_colour(c):
+    global status, colour
+    colour = c
+    if status != 0:
+        blinkt_on(colour)
+        status = 1
+    return jsonify({'status': status, 'colour': colour})
+
+@app.errorhandler(404)
+def not_found(error):
+    return make_response(jsonify({'error': 'Not found'}), 404)
+
+if __name__ == '__main__':
+    blinkt_off()
+    app.run(host='0.0.0.0', debug=True)

--- a/examples/homekit.py
+++ b/examples/homekit.py
@@ -63,12 +63,12 @@ def set_status(st):
         blinkt_off()
     elif st == 'status':
         status = get_status()
-    return jsonify(status)
+    return status
 
 @app.route('/blinkt/api/v1.0/set', methods=['GET'])
 def get_colour():
     global colour, brightness
-    return jsonify(colour)
+    return colour
 
 @app.route('/blinkt/api/v1.0/set/<string:c>', methods=['GET'])
 def set_colour(c):
@@ -77,12 +77,12 @@ def set_colour(c):
     if status != 0:
         blinkt_on(colour)
         status = 1
-    return jsonify({'status': status, 'colour': colour, 'brightness' : brightness})
+    return colour
 
 @app.route('/blinkt/api/v1.0/brightness', methods=['GET'])
 def get_brightness():
     global colour, brightness
-    return jsonify(brightness)
+    return brightness
 
 @app.route('/blinkt/api/v1.0/brightness/<string:x>', methods=['GET'])
 def set_brightness(x):
@@ -91,7 +91,7 @@ def set_brightness(x):
     if status != 0:
         blinkt_on(colour)
         status = 1
-    return jsonify({'status': status, 'colour': colour, 'brightness' : brightness})
+    return brightness
 
 @app.errorhandler(404)
 def not_found(error):

--- a/examples/homekit_multi-sample-config.json
+++ b/examples/homekit_multi-sample-config.json
@@ -1,0 +1,183 @@
+{
+    "bridge": {
+        "name": "Homebridge",
+        "username": "CC:22:3D:E3:CE:32",
+        "port": 51826,
+        "pin": "031-45-155"
+    },
+
+    "description": "Homebridge",
+
+    "accessories": [
+        {
+            "accessory": "HTTP-RGB",
+            "name": "Blinkt1",
+
+            "switch": {
+                "status": "http://127.0.0.1:5000/blinkt/api/v1.0/0/status",
+                "powerOn": "http://127.0.0.1:5000/blinkt/api/v1.0/0/on",
+                "powerOff": "http://127.0.0.1:5000/blinkt/api/v1.0/0/off"
+            },
+
+            "brightness": {
+                "status": "http://127.0.0.1:5000/blinkt/api/v1.0/0/brightness",
+                "url": "http://127.0.0.1:5000/blinkt/api/v1.0/0/brightness/%s"
+            },
+
+            "color": {
+                "status": "http://127.0.0.1:5000/blinkt/api/v1.0/0/set",
+                "url": "http://127.0.0.1:5000/blinkt/api/v1.0/0/set/%s",
+                "brightness": true
+            }
+        },
+        {
+            "accessory": "HTTP-RGB",
+            "name": "Blinkt2",
+
+            "switch": {
+                "status": "http://127.0.0.1:5000/blinkt/api/v1.0/1/status",
+                "powerOn": "http://127.0.0.1:5000/blinkt/api/v1.0/1/on",
+                "powerOff": "http://127.0.0.1:5000/blinkt/api/v1.0/1/off"
+            },
+
+            "brightness": {
+                "status": "http://127.0.0.1:5000/blinkt/api/v1.0/1/brightness",
+                "url": "http://127.0.0.1:5000/blinkt/api/v1.0/1/brightness/%s"
+            },
+
+            "color": {
+                "status": "http://127.0.0.1:5000/blinkt/api/v1.0/1/set",
+                "url": "http://127.0.0.1:5000/blinkt/api/v1.0/1/set/%s",
+                "brightness": true
+            }
+        },
+        {
+            "accessory": "HTTP-RGB",
+            "name": "Blinkt3",
+
+            "switch": {
+                "status": "http://127.0.0.1:5000/blinkt/api/v1.0/2/status",
+                "powerOn": "http://127.0.0.1:5000/blinkt/api/v1.0/2/on",
+                "powerOff": "http://127.0.0.1:5000/blinkt/api/v1.0/2/off"
+            },
+
+            "brightness": {
+                "status": "http://127.0.0.1:5000/blinkt/api/v1.0/2/brightness",
+                "url": "http://127.0.0.1:5000/blinkt/api/v1.0/2/brightness/%s"
+            },
+
+            "color": {
+                "status": "http://127.0.0.1:5000/blinkt/api/v1.0/2/set",
+                "url": "http://127.0.0.1:5000/blinkt/api/v1.0/2/set/%s",
+                "brightness": true
+            }
+        },
+        {
+            "accessory": "HTTP-RGB",
+            "name": "Blinkt4",
+
+            "switch": {
+                "status": "http://127.0.0.1:5000/blinkt/api/v1.0/3/status",
+                "powerOn": "http://127.0.0.1:5000/blinkt/api/v1.0/3/on",
+                "powerOff": "http://127.0.0.1:5000/blinkt/api/v1.0/3/off"
+            },
+
+            "brightness": {
+                "status": "http://127.0.0.1:5000/blinkt/api/v1.0/3/brightness",
+                "url": "http://127.0.0.1:5000/blinkt/api/v1.0/3/brightness/%s"
+            },
+
+            "color": {
+                "status": "http://127.0.0.1:5000/blinkt/api/v1.0/3/set",
+                "url": "http://127.0.0.1:5000/blinkt/api/v1.0/3/set/%s",
+                "brightness": true
+            }
+        },
+        {
+            "accessory": "HTTP-RGB",
+            "name": "Blinkt5",
+
+            "switch": {
+                "status": "http://127.0.0.1:5000/blinkt/api/v1.0/4/status",
+                "powerOn": "http://127.0.0.1:5000/blinkt/api/v1.0/4/on",
+                "powerOff": "http://127.0.0.1:5000/blinkt/api/v1.0/4/off"
+            },
+
+            "brightness": {
+                "status": "http://127.0.0.1:5000/blinkt/api/v1.0/4/brightness",
+                "url": "http://127.0.0.1:5000/blinkt/api/v1.0/4/brightness/%s"
+            },
+
+            "color": {
+                "status": "http://127.0.0.1:5000/blinkt/api/v1.0/4/set",
+                "url": "http://127.0.0.1:5000/blinkt/api/v1.0/4/set/%s",
+                "brightness": true
+            }
+        },
+        {
+            "accessory": "HTTP-RGB",
+            "name": "Blinkt6",
+
+            "switch": {
+                "status": "http://127.0.0.1:5000/blinkt/api/v1.0/5/status",
+                "powerOn": "http://127.0.0.1:5000/blinkt/api/v1.0/5/on",
+                "powerOff": "http://127.0.0.1:5000/blinkt/api/v1.0/5/off"
+            },
+
+            "brightness": {
+                "status": "http://127.0.0.1:5000/blinkt/api/v1.0/5/brightness",
+                "url": "http://127.0.0.1:5000/blinkt/api/v1.0/5/brightness/%s"
+            },
+
+            "color": {
+                "status": "http://127.0.0.1:5000/blinkt/api/v1.0/5/set",
+                "url": "http://127.0.0.1:5000/blinkt/api/v1.0/5/set/%s",
+                "brightness": true
+            }
+        },
+        {
+            "accessory": "HTTP-RGB",
+            "name": "Blinkt7",
+
+            "switch": {
+                "status": "http://127.0.0.1:5000/blinkt/api/v1.0/6/status",
+                "powerOn": "http://127.0.0.1:5000/blinkt/api/v1.0/6/on",
+                "powerOff": "http://127.0.0.1:5000/blinkt/api/v1.0/6/off"
+            },
+
+            "brightness": {
+                "status": "http://127.0.0.1:5000/blinkt/api/v1.0/6/brightness",
+                "url": "http://127.0.0.1:5000/blinkt/api/v1.0/6/brightness/%s"
+            },
+
+            "color": {
+                "status": "http://127.0.0.1:5000/blinkt/api/v1.0/6/set",
+                "url": "http://127.0.0.1:5000/blinkt/api/v1.0/6/set/%s",
+                "brightness": true
+            }
+        },
+        {
+            "accessory": "HTTP-RGB",
+            "name": "Blinkt8",
+
+            "switch": {
+                "status": "http://127.0.0.1:5000/blinkt/api/v1.0/7/status",
+                "powerOn": "http://127.0.0.1:5000/blinkt/api/v1.0/7/on",
+                "powerOff": "http://127.0.0.1:5000/blinkt/api/v1.0/7/off"
+            },
+
+            "brightness": {
+                "status": "http://127.0.0.1:5000/blinkt/api/v1.0/7/brightness",
+                "url": "http://127.0.0.1:5000/blinkt/api/v1.0/7/brightness/%s"
+            },
+
+            "color": {
+                "status": "http://127.0.0.1:5000/blinkt/api/v1.0/7/set",
+                "url": "http://127.0.0.1:5000/blinkt/api/v1.0/7/set/%s",
+                "brightness": true
+            }
+        }
+    ],
+
+    "platforms": []
+}

--- a/examples/homekit_multi.py
+++ b/examples/homekit_multi.py
@@ -92,5 +92,6 @@ def not_found(error):
     return make_response(jsonify({'error': 'Not found'}), 404)
 
 if __name__ == '__main__':
-    blinkt_off()
+    for i in range(NUM_PIXELS):
+        blinkt_off(i)
     app.run(host='0.0.0.0', debug=True)

--- a/examples/homekit_multi.py
+++ b/examples/homekit_multi.py
@@ -1,0 +1,96 @@
+from colorsys import hsv_to_rgb, rgb_to_hsv
+import blinkt
+from flask import Flask, jsonify, make_response
+
+app = Flask(__name__)
+
+# Initialize blinkt device
+blinkt.set_clear_on_exit(True)
+blinkt.clear()
+blinkt.show()
+
+NUM_PIXELS = 8
+
+# We're going to use a multi-dimensional (8x3) array / list to hold our status, colour and brightness for each of the 8 LEDs
+status = []
+for i in range(NUM_PIXELS):
+    status.append(['FFFFFF', 0, 50])
+
+def hex_to_rgb(value):
+    value = value.lstrip('#')
+    length = len(value)
+    return tuple(int(value[i:i + length / 3], 16) for i in range(0, length, length / 3))
+
+def blinkt_on(p,c):
+    global status
+    r, g, b = hex_to_rgb(c)
+    blinkt.set_pixel(p, r, g, b, float(status[p][2])/100)
+    status[p][1] = 1
+    status[p][0] = c
+    blinkt.show()
+    return True
+
+def blinkt_off(p):
+    global status
+    blinkt.set_pixel(p, 0, 0, 0, float(status[p][2])/100)
+    blinkt.show()
+    status[p][1] = 0
+    return True
+
+def blinkt_brightness_get(p):
+    global status
+    return status[p][2]
+
+def blinkt_brightness_set(p,b):
+    global status
+    status[p][2] = b
+    blinkt_on(p,status[p][0])
+    return True
+
+def get_status(p):
+    global status
+    return status[p][1]
+
+@app.route('/blinkt/api/v1.0/<int:p>/<string:st>', methods=['GET'])
+def set_status(p,st):
+    global status
+    if st == 'on':
+        blinkt_on(p,status[p][0])
+    elif st == 'off':
+        blinkt_off(p)
+    elif st == 'status':
+        ret = get_status(p)
+    return str(get_status(p))
+
+@app.route('/blinkt/api/v1.0/<int:p>/set', methods=['GET'])
+def get_colour(p):
+    global status
+    return str(status[p][0])
+
+@app.route('/blinkt/api/v1.0/<int:p>/set/<string:c>', methods=['GET'])
+def set_colour(p,c):
+    global status
+    if status[p][1] != 0:
+        blinkt_on(p,c)
+    return str(c)
+
+@app.route('/blinkt/api/v1.0/<int:p>/brightness', methods=['GET'])
+def get_brightness(p):
+    global status
+    return str(status[p][2])
+
+@app.route('/blinkt/api/v1.0/<int:p>/brightness/<string:x>', methods=['GET'])
+def set_brightness(p,x):
+    global status
+    status[p][2] = int(x)
+    if status[p][1] != 0:
+        blinkt_on(p,status[p][0])
+    return str(x)
+
+@app.errorhandler(404)
+def not_found(error):
+    return make_response(jsonify({'error': 'Not found'}), 404)
+
+if __name__ == '__main__':
+    blinkt_off()
+    app.run(host='0.0.0.0', debug=True)

--- a/examples/homekit_patterns-sample-config.json
+++ b/examples/homekit_patterns-sample-config.json
@@ -1,0 +1,25 @@
+{
+    "bridge": {
+        "name": "Homebridge",
+        "username": "CC:22:3D:E3:CE:32",
+        "port": 51826,
+        "pin": "031-45-155"
+    },
+
+    "description": "Homebridge",
+
+    "accessories": [
+        {
+            "accessory": "HTTP-RGB",
+            "name": "BlinktCycle",
+
+            "switch": {
+                "status": "http://127.0.0.1:5000/blinkt/api/v1.0/pattern/cycle/status",
+                "powerOn": "http://127.0.0.1:5000/blinkt/api/v1.0/pattern/cycle/on",
+                "powerOff": "http://127.0.0.1:5000/blinkt/api/v1.0/pattern/cycle/off"
+            }
+        }
+    ],
+
+    "platforms": []
+}

--- a/examples/homekit_patterns.py
+++ b/examples/homekit_patterns.py
@@ -1,0 +1,94 @@
+from colorsys import hsv_to_rgb, rgb_to_hsv
+import blinkt
+from flask import Flask, jsonify, make_response
+import threading
+import time
+from concurrent.futures import TimeoutError
+from pebble import ProcessPool, ProcessExpired
+
+app = Flask(__name__)
+
+# Initialize blinkt device
+blinkt.set_clear_on_exit(True)
+blinkt.clear()
+blinkt.show()
+
+NUM_PIXELS = 8
+
+
+def runPattern(n):
+    # As long as we weren't asked to stop, do our pattern
+    spacing = 360.0 / 16.0
+    hue = 0
+    global thread_stopReq
+    while not thread_stopReq:
+        hue = int(time.time() * 2) % 360
+        h = (hue % 360) / 360.0
+        r, g, b = [int(c*255) for c in hsv_to_rgb(h, 1.0, 1.0)]
+        blinkt.set_all(r,g,b,1)
+        blinkt.show()
+        time.sleep(0.001)
+        global thread_stopReq
+    return n
+
+thread_running = False;
+thread_stopReq = False;
+
+with ProcessPool() as pool:
+    future = pool.map(function, 0, None)
+    if
+
+def pattern_cycle_on():
+    try:
+        thread.start()
+        thread_running = True
+    except:
+        thread = PatternThread()
+        thread.start()
+        thread_running = True
+    return True
+
+def pattern_cycle_off():
+    try:
+        thread.join()
+        blinkt.clear()
+        blinkt.show()
+        thread_running = False
+    except:
+        blinkt.clear()
+        blinkt.show()
+        thread_running = False
+    return True
+
+def pattern_cycle_status():
+    return thread_running
+
+def hex_to_rgb(value):
+    value = value.lstrip('#')
+    length = len(value)
+    return tuple(int(value[i:i + length / 3], 16) for i in range(0, length, length / 3))
+
+def clamp(x):
+  return max(0, min(x, 255))
+
+def rgb_to_hex(r,g,b):
+    return "#{0:02x}{1:02x}{2:02x}".format(clamp(r), clamp(g), clamp(b))
+
+@app.route('/blinkt/api/v1.0/pattern/<string:pat>/<string:st>', methods=['GET'])
+def set_pattern(pat,st):
+    if st == 'on':
+        if pat == 'cycle':
+            pattern_cycle_on()
+    elif st == 'off':
+        if pat == 'cycle':
+            pattern_cycle_off()
+    elif st == 'status':
+        return str(pattern_cycle_status())
+    return str(pattern_cycle_status())
+
+@app.errorhandler(404)
+def not_found(error):
+    return make_response(jsonify({'error': 'Not found'}), 404)
+
+if __name__ == '__main__':
+    app.run(host='0.0.0.0', debug=True)

--- a/examples/rainbow_cycle.py
+++ b/examples/rainbow_cycle.py
@@ -1,0 +1,21 @@
+#!/usr/bin/env python
+
+import colorsys
+import time
+
+from blinkt import set_clear_on_exit, set_brightness, set_all, show
+
+
+spacing = 360.0 / 16.0
+hue = 0
+
+set_clear_on_exit()
+set_brightness(1)
+
+while True:
+    hue = int(time.time() * 2) % 360
+    h = (hue % 360) / 360.0
+    r, g, b = [int(c*255) for c in colorsys.hsv_to_rgb(h, 1.0, 1.0)]
+    set_all(r,g,b)
+    show()
+    time.sleep(0.001)


### PR DESCRIPTION
Hey pirates,

A morning of tinkering has resulted in a little port and extension of your "Using Mote with HomeKit and Siri" guide (https://learn.pimoroni.com/tutorial/sandyj/using-mote-with-homekit-and-siri) for your blinkt LED strip. 

Functionality is pretty much the same as for Mote, but I've added brightness (can't add this to Mote as I don't have any of these for testing).

Instructions have been added to the README, based almost entirely on the aforementioned Mote guide.

Thanks for the great work.

Phil