### PR TITLE
Re-order Dockerfile for more efficient rebuilding of examples

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -3,10 +3,18 @@ FROM resin/rpi-raspbian:jessie
 RUN apt-get update -qy && apt-get install -qy \
     python \
     python-rpi.gpio
+
+# Cancel out any Entrypoint already set in the base image.
+ENTRYPOINT []	
+
 WORKDIR /root/
-COPY . .
+
+COPY library	library
 WORKDIR /root/library
 RUN python setup.py install
+
+WORKDIR /root/
+COPY examples	examples
 WORKDIR /root/examples/
-ENTRYPOINT []
+
 CMD ["python", "larson.py"]


### PR DESCRIPTION
**What I did:**

Allows container image to be rebuilt without re-installing everything if only the examples have changed.

**Why I did it:**

Needed for Sponsored Dockercon Workshop

**How did I test it?**

On a Pi Zero

```
$ docker build -t blinkt .
$ docker run --privileged -ti blinkt
```

@Gadgetoid  