### PR TITLE
Better portability with alternative GPIO library.

### DIFF
--- a/library/blinkt.py
+++ b/library/blinkt.py
@@ -66,7 +66,8 @@ def show():
     if not _gpio_setup:
         GPIO.setmode(GPIO.BCM)
         GPIO.setwarnings(False)
-        GPIO.setup([DAT,CLK],GPIO.OUT)
+        GPIO.setup(DAT,GPIO.OUT)
+        GPIO.setup(CLK,GPIO.OUT)
         _gpio_setup = True
 
     _sof()


### PR DESCRIPTION
Under CHIP processor and the CHIP_IO.GPIO library, pin are string.
So DAT and CLK are not number but need to be replace by string.

This help use Blinkt! library on other platform.