### PR TITLE
print compatible between python2 and python3

### DIFF
--- a/examples/twitter_monitor.py
+++ b/examples/twitter_monitor.py
@@ -23,7 +23,7 @@ class listener(StreamListener):
         return True
 
     def on_error(self, status):
-        print status
+        print(status)
 
 def blink_blinkt():
     for i in range(3):


### PR DESCRIPTION
Not sure if the twitter example still work (for me it only display 401).
But at least now it run with python2 and python3.