### PR TITLE
fix link error for write_byte using gcc 7.2

### DIFF
--- a/library_c/lib/blinkt.c
+++ b/library_c/lib/blinkt.c
@@ -65,7 +65,7 @@ uint32_t rgb(uint8_t r, uint8_t g, uint8_t b){
 	return rgbb(r, g, b, DEFAULT_BRIGHTNESS);
 }
 
-inline void write_byte(uint8_t byte){
+inline static void write_byte(uint8_t byte){
 	int n;
 	for(n = 0; n < 8; n++){
 		bcm2835_gpio_write(MOSI, (byte & (1 << (7-n))) > 0);


### PR DESCRIPTION
`
gcc -Wall -DTEST lib/blinkt.c -l bcm2835 -o blinkt
/tmp/ccjHD5qV.o: In function `show':
blinkt.c:(.text+0x318): undefined reference to `write_byte'
blinkt.c:(.text+0x320): undefined reference to `write_byte'
blinkt.c:(.text+0x328): undefined reference to `write_byte'
blinkt.c:(.text+0x330): undefined reference to `write_byte'
blinkt.c:(.text+0x374): undefined reference to `write_byte'
/tmp/ccjHD5qV.o:blinkt.c:(.text+0x39c): more undefined references to `write_byte' follow
collect2: error: ld returned 1 exit status
make: *** [Makefile:2: all] Error 1
`