### PR TITLE
Fixed off by one error

### DIFF
--- a/library_c/lib/blinkt.c
+++ b/library_c/lib/blinkt.c
@@ -37,17 +37,19 @@ void clear(){
 }
 
 void set_pixel(uint8_t led, uint8_t r, uint8_t g, uint8_t b){
-	if(led > NUM_LEDS) return;
+	if(led >= NUM_LEDS) return;
 
 	leds[led] = rgbb(r,g,b,leds[led] & 0b11111);
 }
 
 void set_pixel_brightness(uint8_t led, uint8_t brightness){
+	if(led >= NUM_LEDS) return;
+	
 	leds[led] = (leds[led] & 0xFFFFFF00) | (brightness & 0b11111);
 }
 
 void set_pixel_uint32(uint8_t led, uint32_t color){
-	if(led > NUM_LEDS) return;
+	if(led >= NUM_LEDS) return;
 
 	leds[led] = color;
 }


### PR DESCRIPTION
Fixed error inside set_pixel when led = 8 that would cause a write outside the bounds of the leds array.
Added bounds checking to set_pixel_brightness function for consistency.