### PR TITLE
MQTT example: add multiple topics; add timeouts

### DIFF
--- a/examples/mqtt.py
+++ b/examples/mqtt.py
@@ -27,6 +27,7 @@ It will monitor the {topic} topic by default, and understands the following mess
 
 rgb,<pixel>,<r>,<g>,<b> - Set a single pixel to an RGB colour. Example: rgb,1,255,0,255
 clr - Clear Blinkt!
+bri,<val> - Set global brightness (for val in range 0.0-1.0)
 
 You can use the online MQTT tester at http://www.hivemq.com/demos/websocket-client/ to send messages.
 
@@ -49,6 +50,16 @@ def on_message(client, userdata, msg):
 
     if command == "clr" and len(data) == 0:
         blinkt.clear()
+        blinkt.show()
+        return
+
+    if command == "bri" and len(data) == 1:
+        try:
+            bri = float(data[0])
+        except ValueError:
+            print("Malformed command: ", str(msg.payload))
+            return
+        blinkt.set_brightness(bri)
         blinkt.show()
         return
 

--- a/examples/mqtt.py
+++ b/examples/mqtt.py
@@ -163,6 +163,9 @@ def sigterm( signum, frame ):
     client._thread_terminate = True
 
 if args.daemon:
+    # Monkey-patch daemon so's the daemon starts reasonably quickly.  FDs don't
+    # strictly speaking need closing anyway because we haven't opened any (yet).
+    daemon.daemon.get_maximum_file_descriptors = lambda: 32
     args.quiet = True
     pidlf = lockfile.pidlockfile.PIDLockFile( args.daemon )
     with daemon.DaemonContext(

--- a/examples/mqtt.py
+++ b/examples/mqtt.py
@@ -1,6 +1,7 @@
 #!/usr/bin/env python
 
 from sys import exit
+import argparse
 
 try:
     import paho.mqtt.client as mqtt
@@ -18,7 +19,7 @@ MQTT_TOPIC = "pimoroni/blinkt"
 MQTT_USER = None
 MQTT_PASS = None
 
-print("""
+description = """\
 MQTT Blinkt! Control
 
 This example uses public MQTT messages from {server} on port {port} to control Blinkt!
@@ -36,10 +37,31 @@ Use {server} as the host, and port 80 (Eclipse's websocket port). Set the topic 
     server=MQTT_SERVER,
     port=MQTT_PORT,
     topic=MQTT_TOPIC
-))
+)
+parser = argparse.ArgumentParser(description = description, formatter_class = argparse.RawDescriptionHelpFormatter)
+parser.add_argument( '-H', '--host', default = MQTT_SERVER,
+                        help = 'MQTT broker to connect to' )
+parser.add_argument( '-P', '--port', default = MQTT_PORT, type = int,
+                        help = 'port on MQTT broker to connect to' )
+parser.add_argument( '-T', '--topic', default = MQTT_TOPIC,
+                        help = 'MQTT topic to subscribe to' )
+parser.add_argument( '-u', '--user',
+                        help = 'MQTT broker user name' )
+parser.add_argument( '-p', '--pass', dest = 'pw',
+                        help = 'MQTT broker password' )
+parser.add_argument( '-q', '--quiet', default = False, action = 'store_true',
+                        help = 'Minimal output (eg for running as a daemon)' )
+args = parser.parse_args()
+
+MQTT_SERVER = args.host
+MQTT_PORT = args.port
+MQTT_TOPIC = args.topic
+MQTT_USER = args.user
+MQTT_PASS = args.pw
 
 def on_connect(client, userdata, flags, rc):
-    print("Connected with result code "+str(rc))
+    if not args.quiet:
+        print("Connected to {s}:{p}/{t} with result code {r}.\nSee {c} --help for options.".format(s = MQTT_SERVER, p = MQTT_PORT, t = MQTT_TOPIC, r = rc, c = parser.prog))
 
     client.subscribe(MQTT_TOPIC)
 

--- a/examples/mqtt.py
+++ b/examples/mqtt.py
@@ -45,8 +45,8 @@ parser.add_argument( '-H', '--host', default = MQTT_SERVER,
                         help = 'MQTT broker to connect to' )
 parser.add_argument( '-P', '--port', default = MQTT_PORT, type = int,
                         help = 'port on MQTT broker to connect to' )
-parser.add_argument( '-T', '--topic', default = MQTT_TOPIC,
-                        help = 'MQTT topic to subscribe to' )
+parser.add_argument( '-T', '--topic', action = 'append',
+                        help = 'MQTT topic to subscribe to; can be repeated for multiple topics' )
 parser.add_argument( '-u', '--user',
                         help = 'MQTT broker user name' )
 parser.add_argument( '-p', '--pass', dest = 'pw',
@@ -87,7 +87,7 @@ if args.daemon:
 
 MQTT_SERVER = args.host
 MQTT_PORT = args.port
-MQTT_TOPIC = args.topic
+MQTT_TOPIC = args.topic and args.topic or [MQTT_TOPIC]
 MQTT_USER = args.user
 MQTT_PASS = args.pw
 
@@ -155,9 +155,10 @@ class PixelClient( mqtt.Client ):
 
     def on_connect(self, client, userdata, flags, rc):
         if not args.quiet:
-            print("Connected to {s}:{p}/{t} with result code {r}.\nSee {c} --help for options.".format(s = MQTT_SERVER, p = MQTT_PORT, t = MQTT_TOPIC, r = rc, c = parser.prog))
+            print("Connected to {s}:{p} listening for topics {t} with result code {r}.\nSee {c} --help for options.".format(s = MQTT_SERVER, p = MQTT_PORT, t = ', '.join(MQTT_TOPIC), r = rc, c = parser.prog))
 
-        client.subscribe(MQTT_TOPIC)
+        for topic in MQTT_TOPIC:
+            client.subscribe(topic)
 
     def on_message(self, client, userdata, msg):
 

--- a/examples/mqtt.py
+++ b/examples/mqtt.py
@@ -51,6 +51,8 @@ parser.add_argument( '-p', '--pass', dest = 'pw',
                         help = 'MQTT broker password' )
 parser.add_argument( '-q', '--quiet', default = False, action = 'store_true',
                         help = 'Minimal output (eg for running as a daemon)' )
+parser.add_argument( '-g', '--green-hack', default = False, action = 'store_true',
+                        help = 'Apply hack to green channel to improve colour saturation' )
 parser.add_argument( '-D', '--daemon', default = False, action = 'store_true',
                         help = 'Run as a daemon (implies -q)' )
 args = parser.parse_args()
@@ -106,6 +108,18 @@ def on_message(client, userdata, msg):
                     return
 
             r, g, b = [int(x) & 0xff for x in data]
+            if args.green_hack:
+                # Green is about twice the luminosity for a given value
+                # than red or blue, so apply a hackish linear compensation
+                # here taking care of corner cases at 0 and 255.  To do it
+                # properly, it should really be a curve but this approximation
+                # is quite a lot better than nothing.
+                if r not in [0,255]:
+                    r = r + 1
+                if g not in [0]:
+                    g = g/2 + 1
+                if b not in [0,255]:
+                    b = b + 1
 
             print(command, pixel, r, g, b)
 


### PR DESCRIPTION
Add support for listening to multiple topics (repeat `--topic` command line flag as many times as desired).  Example use case: I have four pairs of Pi+Blinkt!.  Multitopic support means each pair can listen to a common topic and a pi-specific topic so a publisher can either a pixel on either all or just one of the pairs.

Add support for timing out a pixel.  When enabled, the pixel will be turned off if it hasn't received an update within the specified period of time (in seconds).  Use case: in that environment, a timeout indicates that the publisher has died for some reason and needs attention.

This is a separate PR from #63 because timeouts involved restructuring the code a fair bit and a copy-and-paste of the Paho MQTT client `loop_forever()` method, all for the sake of inserting one method call :persevere: and you might not think it warranted for the benefit gained.