### PR TITLE
Timing fix

### DIFF
--- a/library/blinkt.py
+++ b/library/blinkt.py
@@ -14,6 +14,8 @@ BRIGHTNESS = 7
 
 pixels = [[0, 0, 0, BRIGHTNESS]] * NUM_PIXELS
 
+sleep_time = 0
+
 _gpio_setup = False
 _clear_on_exit = True
 
@@ -48,10 +50,10 @@ def _write_byte(byte):
     for x in range(8):
         GPIO.output(DAT, byte & 0b10000000)
         GPIO.output(CLK, 1)
-        time.sleep(0)
+        time.sleep(sleep_time)
         byte <<= 1
         GPIO.output(CLK, 0)
-        time.sleep(0)
+        time.sleep(sleep_time)
 
 
 # Emit exactly enough clock pulses to latch the small dark die APA102s which are weird
@@ -60,18 +62,18 @@ def _eof():
     GPIO.output(DAT, 0)
     for x in range(36):
         GPIO.output(CLK, 1)
-        time.sleep(0)
+        time.sleep(sleep_time)
         GPIO.output(CLK, 0)
-        time.sleep(0)
+        time.sleep(sleep_time)
 
 
 def _sof():
     GPIO.output(DAT, 0)
     for x in range(32):
         GPIO.output(CLK, 1)
-        time.sleep(0)
+        time.sleep(sleep_time)
         GPIO.output(CLK, 0)
-        time.sleep(0)
+        time.sleep(sleep_time)
 
 
 def show():

--- a/library/blinkt.py
+++ b/library/blinkt.py
@@ -48,10 +48,10 @@ def _write_byte(byte):
     for x in range(8):
         GPIO.output(DAT, byte & 0b10000000)
         GPIO.output(CLK, 1)
-        time.sleep(0.0000005)
+        time.sleep(0)
         byte <<= 1
         GPIO.output(CLK, 0)
-        time.sleep(0.0000005)
+        time.sleep(0)
 
 
 # Emit exactly enough clock pulses to latch the small dark die APA102s which are weird
@@ -60,18 +60,18 @@ def _eof():
     GPIO.output(DAT, 0)
     for x in range(36):
         GPIO.output(CLK, 1)
-        time.sleep(0.0000005)
+        time.sleep(0)
         GPIO.output(CLK, 0)
-        time.sleep(0.0000005)
+        time.sleep(0)
 
 
 def _sof():
     GPIO.output(DAT, 0)
     for x in range(32):
         GPIO.output(CLK, 1)
-        time.sleep(0.0000005)
+        time.sleep(0)
         GPIO.output(CLK, 0)
-        time.sleep(0.0000005)
+        time.sleep(0)
 
 
 def show():


### PR DESCRIPTION
This aims to fix the problem reported in #72 where changes to `time.sleep` behaviour had turned a very tiny delay `0.0000005` into a much longer one.

The purpose of this delay is to allow GPIO state changes to propagate to hardware before the clock is de-asserted. Since `GPIO.output()` effectively returns immediately, and doesn't guarantee that the state change has fully propagated from the register to the GPIO pin (and indeed from the pin to the hardware attached) it requires at least *some* delay.

In this case the 500ns delay intended to, in theory (albeit not in practise since the calls themselves take time), produce an SPI clock frequency of 2MHz, which is well within the capabilities of the Pi.

The `time.sleep(0)` replacement is effectively using the call overhead of `time.sleep()` to provide enough of a delay to ensure the pin state change propagates. This may not be particularly robust.

See also:
https://github.com/pimoroni/mote-phat/pull/14
https://github.com/pimoroni/rainbow-hat/pull/15