### PR TITLE
add eyedropper example

### DIFF
--- a/examples/README.md
+++ b/examples/README.md
@@ -14,6 +14,7 @@ The examples in the `extra_examples` folder are designed to work with other pHAT
 - cheerlights - reads twitter for any tweets with the hashtag "cheerlights" and a colour. Changes all the pixels to that colour. Online.
 - cpu_load - shows a graph of cpu usage as a percentage. May require a psutil install. Offline.
 - cpu_temp - shows a graph of the cpu temperature as a percentage. Offline.
+- eyedropper - shows the rgb value at cursor location real time. Offline.
 - gradient_graph - pulses a rainbow across the blinkt and back again. Offline.
 - graph - pulses a magenta graph across the blinkt and back again. Offline.
 - larson - remember Knight Rider? Offline.

--- a/examples/eyedropper.py
+++ b/examples/eyedropper.py
@@ -1,0 +1,22 @@
+#!/usr/bin/env python3
+
+from PIL import Image, ImageGrab
+import pyautogui, sys
+import blinkt 
+import time
+
+print('Press Ctrl-C to quit.')
+
+try:
+    while True:
+        x, y = pyautogui.position()
+        im = ImageGrab.grab(bbox =(x-1, y, x, y+1))
+        rawrgb = list(im.getdata())
+        rgb = str(rawrgb)[2:-2]   
+        r, g, b =  rgb.split(', ')  
+        blinkt.set_all(r, g, b)
+        blinkt.set_brightness(1)
+        blinkt.show()
+        time.sleep(0.01)
+except KeyboardInterrupt:
+    print('\n')


### PR DESCRIPTION
This is just a quick example to create a real-time eyedropper where the LEDs on the blinkt reflect the rgb value at the mouse cursor. I'm sure it could be optimised but thought I'd put it out there for anyone interested.

quick video in action:

![eyedropper](https://user-images.githubusercontent.com/10035308/107180181-0deeef80-698d-11eb-89be-ec3b4ba72ab3.gif)

Dependencies:

- pillow > 7.1 (I used pip3 install --user pillow==8.1.0)
- pyautogui

pillow and pyautogui depend on x to work, so won't work directly on the framebuffer eg doesn't work on retropie. 

Tested and working on my Raspberry Pi 4 on the latest Buster Desktop Raspberry Pi OS (2021-01-11)