### PR TITLE
Terminal simulation of blinkt library

### DIFF
--- a/examples/eyedropper.py
+++ b/examples/eyedropper.py
@@ -14,7 +14,7 @@ try:
         rawrgb = list(im.getdata())
         rgb = str(rawrgb)[2:-2]
         r, g, b = rgb.split(', ')
-        blinkt.set_all(r, g, b)
+        blinkt.set_all(int(r), int(g), int(b))
         blinkt.set_brightness(1)
         blinkt.show()
         time.sleep(0.01)

--- a/examples/fake_blinkt.py
+++ b/examples/fake_blinkt.py
@@ -1,13 +1,12 @@
 """fake_blink terminal simulation of blinkt, to use rename to blinkt.py and place in same directory as blinkt program"""
 import sys
-import pantilthat
 import atexit
-import signal
 
 _clear_on_exit = True
-_true_color    = True
-NUM_PIXELS     = 8
-pixels         = [(0,0,0,1)] * NUM_PIXELS
+_true_color = True
+NUM_PIXELS = 8
+pixels = [(0, 0, 0, 1)] * NUM_PIXELS
+
 
 def _exit():
     if _clear_on_exit:
@@ -20,20 +19,21 @@ def _exit():
 def set_brightness(brightness):
     pass
 
+
 def clear():
-    pixels[:] = [(0,0,0,1)] * NUM_PIXELS
+    pixels[:] = [(0, 0, 0, 1)] * NUM_PIXELS
 
 
 def show():
     sys.stdout.write(" ")
-    for (r,g,b,_) in pixels:
+    for (r, g, b, _) in pixels:
         if _true_color:
-            sys.stdout.write("\033[48;2;%d;%d;%dm   " % (r,g,b))
+            sys.stdout.write("\033[48;2;%d;%d;%dm   " % (r, g, b))
         else:
-            if r==g==b:
-                col = 232 + r*24//256
+            if r == g == b:
+                col = 232 + (r * 24) // 256
             else:
-                col = 16 + (b*6//256) + (g*6//256)*6 + (r*6//256)*36
+                col = 16 + ((b * 6) // 256) + ((g * 6) // 256) * 6 + ((r * 6) // 256) * 36
             sys.stdout.write("\033[48;5;%dm   " % col)
     sys.stdout.write("\033[0m\r")
     sys.stdout.flush()

--- a/examples/fake_blinkt.py
+++ b/examples/fake_blinkt.py
@@ -7,7 +7,7 @@ import signal
 _clear_on_exit = True
 _true_color    = True
 NUM_PIXELS     = 8
-pixels         = [(0,0,0)] * NUM_PIXELS
+pixels         = [(0,0,0,1)] * NUM_PIXELS
 
 def _exit():
     if _clear_on_exit:
@@ -21,12 +21,12 @@ def set_brightness(brightness):
     pass
 
 def clear():
-    pixels[:] = [(0,0,0)] * NUM_PIXELS
+    pixels[:] = [(0,0,0,1)] * NUM_PIXELS
 
 
 def show():
     sys.stdout.write(" ")
-    for (r,g,b) in pixels:
+    for (r,g,b,_) in pixels:
         if _true_color:
             sys.stdout.write("\033[48;2;%d;%d;%dm   " % (r,g,b))
         else:
@@ -43,14 +43,14 @@ def set_all(r, g, b, brightness=None):
     global _brightness
     if brightness is not None:
         _brightness = brightness
-    pixels[:] = [(r, g, b)] * NUM_PIXELS
+    pixels[:] = [(r, g, b, 1)] * NUM_PIXELS
 
 
 def set_pixel(x, r, g, b, brightness=None):
     global _brightness
     if brightness is not None:
         _brightness = brightness
-    pixels[x] = (r, g, b)
+    pixels[x] = (r, g, b, 1)
 
 
 def get_pixel(x):

--- a/examples/fake_blinkt.py
+++ b/examples/fake_blinkt.py
@@ -1,0 +1,76 @@
+"""fake_blink terminal simulation of blinkt, to use rename to blinkt.py and place in same directory as blinkt program"""
+import sys
+import pantilthat
+import atexit
+import signal
+
+_clear_on_exit = True
+_true_color    = True
+NUM_PIXELS     = 8
+pixels         = [(0,0,0)] * NUM_PIXELS
+
+def _exit():
+    if _clear_on_exit:
+        clear()
+        show()
+    else:
+        print("")
+
+
+def set_brightness(brightness):
+    pass
+
+def clear():
+    pixels[:] = [(0,0,0)] * NUM_PIXELS
+
+
+def show():
+    sys.stdout.write(" ")
+    for (r,g,b) in pixels:
+        if _true_color:
+            sys.stdout.write("\033[48;2;%d;%d;%dm   " % (r,g,b))
+        else:
+            if r==g==b:
+                col = 232 + r*24//256
+            else:
+                col = 16 + (b*6//256) + (g*6//256)*6 + (r*6//256)*36
+            sys.stdout.write("\033[48;5;%dm   " % col)
+    sys.stdout.write("\033[0m\r")
+    sys.stdout.flush()
+
+
+def set_all(r, g, b, brightness=None):
+    global _brightness
+    if brightness is not None:
+        _brightness = brightness
+    pixels[:] = [(r, g, b)] * NUM_PIXELS
+
+
+def set_pixel(x, r, g, b, brightness=None):
+    global _brightness
+    if brightness is not None:
+        _brightness = brightness
+    pixels[x] = (r, g, b)
+
+
+def get_pixel(x):
+    return pixels[x]
+
+
+def set_clear_on_exit(value=True):
+    """Set whether Blinkt! should be cleared upon exit
+
+    By default Blinkt! will turn off the pixels on exit, but calling::
+
+        blinkt.set_clear_on_exit(False)
+
+    Will ensure that it does not.
+
+    :param value: True or False (default True)
+    """
+    global _clear_on_exit
+    _clear_on_exit = value
+
+
+# Module Initialisation
+atexit.register(_exit)

--- a/examples/rampup.py
+++ b/examples/rampup.py
@@ -1,0 +1,10 @@
+#!/usr/bin/env python
+import sys
+from time import sleep
+import blinkt
+
+for i in range(256):
+    blinkt.set_all(i, i, i)
+    sys.stdout.write("%3d" % i)
+    blinkt.show()
+    sleep(0.1)

--- a/examples/rampup.py
+++ b/examples/rampup.py
@@ -4,7 +4,7 @@ from time import sleep
 import blinkt
 
 for i in range(256):
-    blinkt.set_all(i, i, i)
+    blinkt.set_all(i, i, i, 1.0)
     sys.stdout.write("%3d" % i)
     blinkt.show()
     sleep(0.1)


### PR DESCRIPTION
This is s small routine which can be used to test out code intended for use with a blinkt panel, but either without the hardware installed on the machine, or if using a Raspberry Pi remotely via VNC or ssh. Instead it simulates the blinkt display by drawing coloured squares on a Linux terminal.

To Use:
If a file called blinkt.py is in the current directory it will be used by programs in that directory instead of the real blink library. The easiest way to do this is to create a soft link to fake_blinkt.py.

`ln -s fake_blinkt.py blinkt.py`

After testing and to use the real blink library, just delete the link with `rm blinkt.py`

If the terminal does not support true colour output, set `_true_color = False` at line 6.