### PR TITLE
Raspberry Pi OS Bullseye support

### DIFF
--- a/examples/1d_tetris.py
+++ b/examples/1d_tetris.py
@@ -1,4 +1,4 @@
-#!/usr/bin/env python
+#!/usr/bin/env python3
 
 import time
 from random import randint

--- a/examples/anvil-colour-control.py
+++ b/examples/anvil-colour-control.py
@@ -1,3 +1,4 @@
+#!/usr/bin/env python3
 # Basic example for controlling the Blinkt LED colours via Anvil
 # Learn more at: https://anvil.works/
 #

--- a/examples/binary_clock.py
+++ b/examples/binary_clock.py
@@ -1,4 +1,4 @@
-#!/usr/bin/env python
+#!/usr/bin/env python3
 
 from time import localtime, sleep
 

--- a/examples/binary_clock_meld.py
+++ b/examples/binary_clock_meld.py
@@ -1,4 +1,4 @@
-#!/usr/bin/env python
+#!/usr/bin/env python3
 
 from time import localtime, sleep
 

--- a/examples/blinkt_thermo.py
+++ b/examples/blinkt_thermo.py
@@ -1,4 +1,4 @@
-#!/usr/bin/env python
+#!/usr/bin/env python3
 
 # Data from OpenWeatherMap
 # show_graph function adapted from cpu_temp.py

--- a/examples/candle.py
+++ b/examples/candle.py
@@ -1,4 +1,4 @@
-#!/usr/bin/env python
+#!/usr/bin/env python3
 
 import colorsys
 import time

--- a/examples/cheerlights.py
+++ b/examples/cheerlights.py
@@ -1,4 +1,4 @@
-#!/usr/bin/env python
+#!/usr/bin/env python3
 import time
 from sys import exit
 

--- a/examples/cpu_load.py
+++ b/examples/cpu_load.py
@@ -1,4 +1,4 @@
-#!/usr/bin/env python
+#!/usr/bin/env python3
 import time
 from sys import exit
 

--- a/examples/cpu_temp.py
+++ b/examples/cpu_temp.py
@@ -1,4 +1,4 @@
-#!/usr/bin/env python
+#!/usr/bin/env python3
 
 import time
 from subprocess import PIPE, Popen

--- a/examples/extra_examples/drum_hits.py
+++ b/examples/extra_examples/drum_hits.py
@@ -1,4 +1,4 @@
-#!/usr/bin/env python
+#!/usr/bin/env python3
 
 import glob
 import os

--- a/examples/extra_examples/pov_rainbow.py
+++ b/examples/extra_examples/pov_rainbow.py
@@ -1,4 +1,4 @@
-#!/usr/bin/env python
+#!/usr/bin/env python3
 
 import time
 from colorsys import hsv_to_rgb

--- a/examples/extra_examples/spirit_level.py
+++ b/examples/extra_examples/spirit_level.py
@@ -1,4 +1,4 @@
-#!/usr/bin/env python
+#!/usr/bin/env python3
 
 import time
 from sys import exit

--- a/examples/gradient_graph.py
+++ b/examples/gradient_graph.py
@@ -1,4 +1,4 @@
-#!/usr/bin/env python
+#!/usr/bin/env python3
 
 import colorsys
 import math

--- a/examples/graph.py
+++ b/examples/graph.py
@@ -1,4 +1,4 @@
-#!/usr/bin/env python
+#!/usr/bin/env python3
 
 import math
 import time

--- a/examples/half.py
+++ b/examples/half.py
@@ -1,4 +1,4 @@
-#!/usr/bin/env python
+#!/usr/bin/env python3
 
 import blinkt
 

--- a/examples/kitt.py
+++ b/examples/kitt.py
@@ -1,4 +1,4 @@
-#!/usr/bin/env python
+#!/usr/bin/env python3
 
 import time          # so we can wait between frames
 import blinkt        # so we can talk to our blinkt lights!

--- a/examples/larson.py
+++ b/examples/larson.py
@@ -1,4 +1,4 @@
-#!/usr/bin/env python
+#!/usr/bin/env python3
 
 import time
 

--- a/examples/larson_hue.py
+++ b/examples/larson_hue.py
@@ -1,4 +1,4 @@
-#!/usr/bin/env python
+#!/usr/bin/env python3
 
 import math
 import time

--- a/examples/max.py
+++ b/examples/max.py
@@ -1,4 +1,4 @@
-#!/usr/bin/env python
+#!/usr/bin/env python3
 
 import blinkt
 

--- a/examples/mem_load.py
+++ b/examples/mem_load.py
@@ -1,4 +1,4 @@
-#!/usr/bin/env python
+#!/usr/bin/env python3
 
 import time
 from sys import exit

--- a/examples/morse_code.py
+++ b/examples/morse_code.py
@@ -1,4 +1,4 @@
-#!/usr/bin/env python
+#!/usr/bin/env python3
 
 import time
 

--- a/examples/mqtt.py
+++ b/examples/mqtt.py
@@ -1,4 +1,4 @@
-#!/usr/bin/env python
+#!/usr/bin/env python3
 from sys import exit
 
 try:

--- a/examples/off.py
+++ b/examples/off.py
@@ -1,4 +1,4 @@
-#!/usr/bin/env python
+#!/usr/bin/env python3
 
 import blinkt
 

--- a/examples/pulse.py
+++ b/examples/pulse.py
@@ -1,4 +1,4 @@
-#!/usr/bin/env python
+#!/usr/bin/env python3
 
 import colorsys
 import time

--- a/examples/rainbow.py
+++ b/examples/rainbow.py
@@ -1,4 +1,4 @@
-#!/usr/bin/env python
+#!/usr/bin/env python3
 
 import colorsys
 import time

--- a/examples/random_blink.py
+++ b/examples/random_blink.py
@@ -1,4 +1,4 @@
-#!/usr/bin/env python
+#!/usr/bin/env python3
 
 import random
 import time

--- a/examples/random_blink_colours.py
+++ b/examples/random_blink_colours.py
@@ -1,4 +1,4 @@
-#!/usr/bin/env python
+#!/usr/bin/env python3
 
 import random
 import time

--- a/examples/resistor_clock.py
+++ b/examples/resistor_clock.py
@@ -1,4 +1,4 @@
-#!/usr/bin/env python
+#!/usr/bin/env python3
 
 import time
 

--- a/examples/rgb.py
+++ b/examples/rgb.py
@@ -1,4 +1,4 @@
-#!/usr/bin/env python
+#!/usr/bin/env python3
 
 import sys
 

--- a/examples/setall.py
+++ b/examples/setall.py
@@ -1,4 +1,4 @@
-#!/usr/bin/env python
+#!/usr/bin/env python3
 
 import sys
 from sys import argv

--- a/examples/solid_colours.py
+++ b/examples/solid_colours.py
@@ -1,4 +1,4 @@
-#!/usr/bin/env python
+#!/usr/bin/env python3
 
 import time
 

--- a/examples/solid_colours2.py
+++ b/examples/solid_colours2.py
@@ -1,4 +1,4 @@
-#!/usr/bin/env python
+#!/usr/bin/env python3
 
 import time
 

--- a/examples/solid_colours3.py
+++ b/examples/solid_colours3.py
@@ -1,4 +1,4 @@
-#!/usr/bin/env python
+#!/usr/bin/env python3
 
 import time
 

--- a/examples/twitter_monitor.py
+++ b/examples/twitter_monitor.py
@@ -1,4 +1,4 @@
-#!/usr/bin/env python
+#!/usr/bin/env python3
 
 import time
 from sys import exit

--- a/examples/unionjack.py
+++ b/examples/unionjack.py
@@ -1,4 +1,4 @@
-#!/usr/bin/env python
+#!/usr/bin/env python3
 
 import time
 import blinkt

--- a/examples/white.py
+++ b/examples/white.py
@@ -1,4 +1,4 @@
-#!/usr/bin/env python
+#!/usr/bin/env python3
 
 import blinkt
 


### PR DESCRIPTION
Raspberry Pi OS Bullseye no longer includes Python 2, so all python programs containing `#!/usr/bin/env python` will no longer run directly from the command line unless it is changed to `#!/usr/bin/env python3`.

I have not removed Python 2 support or changed the documentation, the programs can still all be run under Python 2 on older OS's by prefixing the command with python, but will run by default under Python 3.

It probably is time to remove Python 2 support completely, but I'll leave that to the author.