### PR TITLE
README.md: add link to unofficial web-based simulator

### DIFF
--- a/README.md
+++ b/README.md
@@ -87,3 +87,4 @@ sudo python3 setup.py install
 * Java library by @HoldYourWaffle - https://github.com/HoldYourWaffle/blinkt4j
 * Node.js library by @irrelon - https://github.com/irrelon/node-blinkt
 * Rust library by @golemparts - https://github.com/golemparts/blinkt
+* Web-based Prequel simulator by Hugo Simoes - https://prequel-lang.org/examples/blinkp/


### PR DESCRIPTION
This simulator runs on a browser and can be used to prototype animations.

It should be easy to port code between Prequel and other programming languages, [as shown in these examples](https://github.com/prequel-lang/prequel-examples/tree/master/src/blinkp).